### PR TITLE
Bug fixes for using logback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To enable the extension add it to your Trinidad configuration e.g. *trinidad.yml
   extensions:
     logging:
       config: other_properties.properties # this field is optional
-    logging_system: log4j # (optional) defaults to 'log4j', 'logback' and 'jul' are also valid choices
+      logging_system: log4j # (optional) defaults to 'log4j', 'logback' and 'jul' are also valid choices
 ```
 
 Here's a (.properties) configuration example extracted from the Tomcat's doc:

--- a/lib/trinidad_logging_extension.rb
+++ b/lib/trinidad_logging_extension.rb
@@ -7,7 +7,7 @@ module Trinidad
 
       def configure(tomcat)
         @options[:logging_system] ||= 'log4j'
-        @options[:config] ||= @options[:logging_system].eql? 'logback' ?
+        @options[:config] ||= @options[:logging_system].eql?('logback') ?
            'config/trinidad-logging.xml' : 'config/trinidad-logging.properties'
 
         require_common_jars


### PR DESCRIPTION
Hi -

I ran into some issues with using the `logback` system.  First, the indentation issue referenced in #2, and then a TypeError (see below).  These couple of changes resolved my issues, so far anyway.

```
TypeError: can't convert false into String
|                   expand_path at org/jruby/RubyFile.java:720
|           set_config_property at /Users/matt/code/soomo-analytics-collector/vendor/bundle/jruby/1.9/gems/trinidad_logging_extension-1.0.0/lib/trinidad_logging_extension.rb:44
|                     configure at /Users/matt/code/soomo-analytics-collector/vendor/bundle/jruby/1.9/gems/trinidad_logging_extension-1.0.0/lib/trinidad_logging_extension.rb:25
```
